### PR TITLE
[Client] / #117 / FiX: Local Storege의 저장된 Store Id 를 사용해 상세 페이지로 접근

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -77,8 +77,7 @@ function App() {
           navigate('/map');
         })
         .catch(err => {
-          setAlertMessage('잘못된 요청입니다.');
-          openWarningAlertHandler();
+          setIsLogin(false);
           console.log(err);
         });
     }

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -7,7 +7,7 @@ import '../styles/pages/Map.css';
 
 const { kakao } = window;
 
-const Map = ({ navigate, setMarkerStoreInfo }) => {
+const Map = ({ navigate }) => {
   const [storeList, setStoreList] = useState([]);
 
   const storeListHandler = () => {
@@ -60,7 +60,7 @@ const Map = ({ navigate, setMarkerStoreInfo }) => {
         img.src = el.store_image;
         img.alt = '';
         img.onclick = function () {
-          setMarkerStoreInfo(el);
+          localStorage.setItem('clickedMarker', el.id);
           navigate(`/store/:${el.id}`);
         };
         content.appendChild(img);
@@ -81,7 +81,7 @@ const Map = ({ navigate, setMarkerStoreInfo }) => {
         infoTitle.classList.add('customOverlay-title');
         infoTitle.appendChild(document.createTextNode(el.store_name));
         infoTitle.onclick = function () {
-          setMarkerStoreInfo(el);
+          localStorage.setItem('clickedMarker', el.id);
           navigate(`/store/:${el.id}`);
         };
         infoTitleContainer.appendChild(infoTitle);


### PR DESCRIPTION
### PR 타입
- 버그 수정

### 반영 브랜치
- hot-fix/117-get_store_idn -> dev

### 변경 사항
- local storege에 저장된 가게 Id를 올바르게 사용하지 못 해서 다시 localstorege.getItem 함수를 수정하여 올바르게 작동하게 만들었습니다.